### PR TITLE
fix flattenDepth support

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ function IntlPlugin(options) {
   var lowness = options.flattenLowness;
   lowness = undefined === lowness ? 1 : lowness;
   var depth = options.flattenDepth;
-  var flattenOpts = depth ? {} : {maxDepth: depth};
+  var flattenOpts = depth ? {maxDepth: depth} : {};
 
   options.save = function(common) {
     return JSON.stringify(


### PR DESCRIPTION
A wrong condition caused the `flattenDepth` option to be ignored.